### PR TITLE
Fix ClassNotFoundException in precompiled mode

### DIFF
--- a/src/play/modules/hazelcast/HazelcastPlugin.java
+++ b/src/play/modules/hazelcast/HazelcastPlugin.java
@@ -86,6 +86,7 @@ public class HazelcastPlugin extends PlayPlugin implements BeanSource, NamedBean
         config.setProperty("hazelcast.jmx", Play.configuration.getProperty("hazelcast.jmx", "true"));
         config.setProperty("hazelcast.jmx.detailed", Play.configuration.getProperty("hazelcast.jmx.detailed", "true"));
         config.setProperty("hazelcast.shutdownhook.enabled", Play.configuration.getProperty("hazelcast.shutdownhook.enabled", "true"));
+        config.setClassLoader(Play.classloader);
         instance = Hazelcast.newHazelcastInstance(config);
     }
     @Override


### PR DESCRIPTION
Fix problem when running hazelcast in precompiled mode.
References:
https://github.com/payara/Payara/issues/1093
http://stackoverflow.com/questions/26033192/com-hazelcast-nio-serialization-hazelcastserializationexception